### PR TITLE
Convert from useState to useReducer in Provider

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -13,22 +13,44 @@ interface PortalMap {
   [name: string]: React.ReactNode;
 }
 
+type PortalAction = {
+  type: 'portals/SET';
+  name: string;
+  children: React.ReactNode;
+};
+
+function portalReducer(state: PortalMap, action: PortalAction): PortalMap {
+  switch (action.type) {
+    case 'portals/SET': {
+      return {
+        ...state,
+        [action.name]: action.children
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
 export const PortalContext = React.createContext<PortalValue | null>(null);
 
 export function PortalProvider(props: PortalProviderProps): JSX.Element {
-  const [portals, setPortals] = React.useState<PortalMap>({});
+  const [portalState, portalDispatch] = React.useReducer<
+    React.Reducer<PortalMap, PortalAction>
+  >(portalReducer, {});
 
   const setPortal = React.useCallback(
     (name: string, children: React.ReactNode): void => {
-      setPortals({ ...portals, [name]: children });
+      portalDispatch({ type: 'portals/SET', name, children });
     },
-    [portals, setPortals]
+    [portalDispatch]
   );
   const getPortal = React.useCallback(
     (name: string): React.ReactNode | undefined => {
-      return portals[name];
+      return portalState[name];
     },
-    [portals]
+    [portalState]
   );
 
   return (

--- a/src/entrance.tsx
+++ b/src/entrance.tsx
@@ -20,7 +20,7 @@ export function EntrancePortal(props: EntrancePortalProps): null {
     return function cleanup(): void {
       portalValue.setPortal(props.name, null);
     };
-  }, [props.name, props.children]);
+  }, [props.name, props.children, portalValue.setPortal]);
 
   return null;
 }

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -163,6 +163,7 @@ describe('<PortalProvider />', () => {
   });
 
   it('can render multiple entrances for multiple exits', () => {
+    console.log('MAIN BUGGER');
     const portalComponent = render(
       <PortalProvider>
         <div>
@@ -180,6 +181,7 @@ describe('<PortalProvider />', () => {
         </div>
       </PortalProvider>
     );
+    console.log('END MAIN BUGGER');
 
     expect(portalComponent.baseElement.textContent).toEqual(
       'Portals.One.Two.Three.'

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -163,7 +163,6 @@ describe('<PortalProvider />', () => {
   });
 
   it('can render multiple entrances for multiple exits', () => {
-    console.log('MAIN BUGGER');
     const portalComponent = render(
       <PortalProvider>
         <div>
@@ -181,7 +180,6 @@ describe('<PortalProvider />', () => {
         </div>
       </PortalProvider>
     );
-    console.log('END MAIN BUGGER');
 
     expect(portalComponent.baseElement.textContent).toEqual(
       'Portals.One.Two.Three.'

--- a/src/spec.tsx
+++ b/src/spec.tsx
@@ -162,6 +162,30 @@ describe('<PortalProvider />', () => {
     );
   });
 
+  it('can render multiple entrances for multiple exits', () => {
+    const portalComponent = render(
+      <PortalProvider>
+        <div>
+          Portals.
+          <div>
+            <EntrancePortal name='one'>One.</EntrancePortal>
+            <div>
+              <EntrancePortal name='two'>Two.</EntrancePortal>
+            </div>
+            <EntrancePortal name='three'>Three.</EntrancePortal>
+          </div>
+          <ExitPortal name='one' />
+          <ExitPortal name='two' />
+          <ExitPortal name='three' />
+        </div>
+      </PortalProvider>
+    );
+
+    expect(portalComponent.baseElement.textContent).toEqual(
+      'Portals.One.Two.Three.'
+    );
+  });
+
   it('can pass contents from a deeply nested entrance to a deeply nested exit', () => {
     const portalComponent = render(
       <PortalProvider>


### PR DESCRIPTION
Fixes a bug where the `PortalEntrance` was referencing a stale version of the `setPortals` function from the Provider.